### PR TITLE
PsxReverb: remember selected preset

### DIFF
--- a/Plugins/PsxReverb/PsxReverb.cpp
+++ b/Plugins/PsxReverb/PsxReverb.cpp
@@ -79,7 +79,7 @@ void PsxReverb::ProcessBlock(sample** pInputs, sample** pOutputs, int numFrames)
 // Defines the parameters used by the plugin
 //------------------------------------------------------------------------------------------------------------------------------------------
 void PsxReverb::DefinePluginParams() noexcept {
-    GetParam(kPresetIdx)->InitInt("presetIdx", 0, 0, kNumPresets - 1);
+    GetParam(kPresetIdx)->InitInt("presetIdx", 0, 0, kNumPresets - 1, "", IParam::kFlagCannotAutomate);
     GetParam(kMasterVolL)->InitInt("masterVolL", 0, 0, 0x3FFF);
     GetParam(kMasterVolR)->InitInt("masterVolR", 0, 0, 0x3FFF);
     GetParam(kInputVolL)->InitInt("inputVolL", 0, 0, 0x7FFF);

--- a/Plugins/PsxReverb/PsxReverb.cpp
+++ b/Plugins/PsxReverb/PsxReverb.cpp
@@ -20,7 +20,7 @@ PsxReverb::PsxReverb(const InstanceInfo& info) noexcept
 {
     DefinePluginParams();
     DefinePluginPresets();
-    
+
     #if IPLUG_DSP
         DoDspSetup();
     #endif
@@ -48,7 +48,7 @@ void PsxReverb::ProcessBlock(sample** pInputs, sample** pOutputs, int numFrames)
 
     // Process the requested number of samples
     const int numChannels = NOutChansConnected();
-    
+
     for (int frameIdx = 0; frameIdx < numFrames; frameIdx++) {
         // Setup the SPU input sample
         if (numChannels >= 2) {
@@ -190,7 +190,7 @@ void PsxReverb::DoEditorSetup() noexcept {
     mMakeGraphicsFunc = [&]() {
         return MakeGraphics(*this, PLUG_WIDTH, PLUG_HEIGHT, PLUG_FPS, GetScaleForScreen(PLUG_WIDTH, PLUG_HEIGHT));
     };
-    
+
     mLayoutFunc = [&](IGraphics* pGraphics) {
         pGraphics->AttachCornerResizer(EUIResizerMode::Scale, false);
         pGraphics->AttachPanelBackground(COLOR_GRAY);

--- a/Plugins/PsxReverb/PsxReverb.cpp
+++ b/Plugins/PsxReverb/PsxReverb.cpp
@@ -79,7 +79,6 @@ void PsxReverb::ProcessBlock(sample** pInputs, sample** pOutputs, int numFrames)
 // Defines the parameters used by the plugin
 //------------------------------------------------------------------------------------------------------------------------------------------
 void PsxReverb::DefinePluginParams() noexcept {
-    GetParam(kPresetIdx)->InitInt("presetIdx", 0, 0, kNumPresets - 1, "", IParam::kFlagCannotAutomate);
     GetParam(kMasterVolL)->InitInt("masterVolL", 0, 0, 0x3FFF);
     GetParam(kMasterVolR)->InitInt("masterVolR", 0, 0, 0x3FFF);
     GetParam(kInputVolL)->InitInt("inputVolL", 0, 0, 0x7FFF);
@@ -123,6 +122,8 @@ void PsxReverb::DefinePluginParams() noexcept {
     GetParam(kAddrRDiff1)->InitInt("addrRDiff1", 0, 0, UINT16_MAX);
     GetParam(kAddrLDiff2)->InitInt("addrLDiff2", 0, 0, UINT16_MAX);
     GetParam(kAddrRDiff2)->InitInt("addrRDiff2", 0, 0, UINT16_MAX);
+
+    GetParam(kPresetIdx)->InitInt("presetIdx", 0, 0, kNumPresets - 1, "", IParam::kFlagCannotAutomate);
 }
 
 //------------------------------------------------------------------------------------------------------------------------------------------

--- a/Plugins/PsxReverb/PsxReverb.h
+++ b/Plugins/PsxReverb/PsxReverb.h
@@ -52,6 +52,7 @@ enum EParams : uint32_t {
     kAddrRAPF2,     // Reverb APF Address 2: Right
     kVolLIn,        // Reverb Input Volume: Left
     kVolRIn,        // Reverb Input Volume: Right
+    kPresetIdx,     // Reverb preset/mode index
     kNumParams
 };
 

--- a/Plugins/PsxReverb/PsxReverb.h
+++ b/Plugins/PsxReverb/PsxReverb.h
@@ -80,6 +80,9 @@ private:
 
     #if IPLUG_EDITOR
         void DoEditorSetup() noexcept;
+        virtual void OnUIOpen() noexcept override;
+        virtual void OnParamChangeUI(int paramIdx, EParamSource source) noexcept override;
+        void UpdatePresetUI() noexcept;
     #endif
 
     #if IPLUG_DSP

--- a/Plugins/PsxReverb/README.md
+++ b/Plugins/PsxReverb/README.md
@@ -7,7 +7,7 @@ Additionally (for advanced users) it is possible to program new effects. All the
 - This plugin must be run at a sample rate of 44.1 KHz for correct operation, as per the sample rate of the original PlayStation's SPU.
 
 ## Usage - Regular Options:
-- **Choose preset**: use this option to choose one of the available presets. Note: after de-serializing previously saved VST state in a DAW this chooser will appear to have no choice, even if you loaded a preset before. This is normal and does not mean the rest of your settings (or adjustments) for your chosen preset were lost. All VST state is saved, apart from this chooser.
+- **Choose preset**: use this option to choose one of the available presets. Note: In older versions of the plugin, after de-serializing previously saved VST state in a DAW this chooser will appear to have no choice, even if you loaded a preset before. This is normal and does not mean the rest of your settings (or adjustments) for your chosen preset were lost. All VST state is saved, apart from this chooser.
 - **Reverb L/R-Vol**: controls the 'depth' of the reverb effect on the left and right channels. Higher values mean more reverb added to the mix.
 - **Input L/R-Vol**: controls the volume of input passing into the reverb unit on the left and right channels. Normally you would leave this alone, but it may be useful to avoid clipping in some cases.
 - **Master L/R-Vol**: controls the volume of output (dry input + reverb) passing from the reverb unit on the left and right channels.


### PR DESCRIPTION
Baked presets in the iPlug2 framework don't support recalling from previous sessions, to work around this I added a new parameter to the PsxReverb plugin which stores the selected preset/mode index.

When recalling the preset, only the index is restored to avoid overwriting changes to parameters in case the user made any adjustments to them. To avoid serialization compatibility issues the new `kPresetIdx` parameter was added after the already existing parameters so that they keep their same index.