### PR TITLE
PsxReverb: add visual feedback to 'Clear' button

### DIFF
--- a/Plugins/PsxReverb/PsxReverb.cpp
+++ b/Plugins/PsxReverb/PsxReverb.cpp
@@ -222,9 +222,9 @@ void PsxReverb::DoEditorSetup() noexcept {
             new IVButtonControl(
                 IRECT(600, 80, 800, 110),
                 [this](IControl* pCaller){
+                    SplashClickActionFunc(pCaller);
                     std::lock_guard<std::recursive_mutex> lockSpu(mSpuMutex);
                     ClearReverbWorkArea();
-                    pCaller->OnEndAnimation();
                 },
                 "Clear Rev. Work Area",
                 DEFAULT_STYLE,


### PR DESCRIPTION
When clicking on the `Clear Rev. Work Area` button it does it's thing correctly but no visual feedback is displayed to let the user know that the button was clicked, this PR fixes this and makes the button react similarly to the preset selection buttons.