### PR TITLE
PsxReverb: volume sliders improvements

### DIFF
--- a/Plugins/PsxReverb/PsxReverb.cpp
+++ b/Plugins/PsxReverb/PsxReverb.cpp
@@ -79,14 +79,14 @@ void PsxReverb::ProcessBlock(sample** pInputs, sample** pOutputs, int numFrames)
 // Defines the parameters used by the plugin
 //------------------------------------------------------------------------------------------------------------------------------------------
 void PsxReverb::DefinePluginParams() noexcept {
-    GetParam(kMasterVolL)->InitInt("masterVolL", 0, 0, 0x3FFF);
-    GetParam(kMasterVolR)->InitInt("masterVolR", 0, 0, 0x3FFF);
-    GetParam(kInputVolL)->InitInt("inputVolL", 0, 0, 0x7FFF);
-    GetParam(kInputVolR)->InitInt("inputVolR", 0, 0, 0x7FFF);
+    GetParam(kMasterVolL)->InitInt("masterVolL", 0x3FFF, 0, 0x3FFF);
+    GetParam(kMasterVolR)->InitInt("masterVolR", 0x3FFF, 0, 0x3FFF);
+    GetParam(kInputVolL)->InitInt("inputVolL", 0x7FFF, 0, 0x7FFF);
+    GetParam(kInputVolR)->InitInt("inputVolR", 0x7FFF, 0, 0x7FFF);
     GetParam(kReverbVolL)->InitInt("reverbVolL", 0, 0, 0x7FFF);
     GetParam(kReverbVolR)->InitInt("reverbVolR", 0, 0, 0x7FFF);
 
-    GetParam(kWABaseAddr)->InitInt("revBaseAddr", 0, 0, UINT16_MAX);
+    GetParam(kWABaseAddr)->InitInt("revBaseAddr", 0xFFFF, 0, UINT16_MAX);
     GetParam(kVolLIn)->InitInt("volLIn", 0, INT16_MIN, INT16_MAX);
     GetParam(kVolRIn)->InitInt("volRIn", 0, INT16_MIN, INT16_MAX);
     GetParam(kVolIIR)->InitInt("volIIR", 0, INT16_MIN, INT16_MAX);

--- a/Plugins/PsxReverb/PsxReverb.h
+++ b/Plugins/PsxReverb/PsxReverb.h
@@ -68,6 +68,10 @@ public:
     #endif
 
 private:
+    #if IPLUG_EDITOR
+        bool mSyncSliders = true;
+    #endif
+
     #if IPLUG_DSP
         Spu::Core               mSpu;
         std::recursive_mutex    mSpuMutex;
@@ -79,6 +83,8 @@ private:
 
     #if IPLUG_EDITOR
         void DoEditorSetup() noexcept;
+        virtual void OnParamChangeUI(int paramIdx, EParamSource source) noexcept override;
+        void SyncParameters(int fromIdx, int toIdx) noexcept;
     #endif
 
     #if IPLUG_DSP


### PR DESCRIPTION
Adds a toggle button to sync L/R volume sliders values when the user drags one of them, saving time when trying to match the volume in both channels.

![image](https://github.com/BodbDearg/PlayStation1Vsts/assets/7089504/4855d2fa-fd78-4f32-a117-442e5634c19e)

Additionally, default values for some sliders were adjusted to match the "Off" preset (the preset that loads initially), this is to avoid an issue where after resetting the plugin to factory defaults at host level (Reaper in my case) the volume sliders were being set to 0 causing there to be silence (not even the dry sound played).
